### PR TITLE
Support version string comparison operators

### DIFF
--- a/lib/src/Evaluator/condition_evaluator.dart
+++ b/lib/src/Evaluator/condition_evaluator.dart
@@ -336,7 +336,6 @@ class GBConditionEvaluator {
       }
     } else if (attributeValue is List) {
       switch (operator) {
-
         /// Evaluate ELEMENT-MATCH operator - whether condition matches attribute
         case "\$elemMatch":
           return elemMatch(attributeValue, conditionValue);
@@ -373,7 +372,6 @@ class GBConditionEvaluator {
         attributeValue as num;
         bool evaluatedValue = false;
         switch (operator) {
-
           /// Evaluate EQ operator - whether condition equals to attribute
           case '\$eq':
             evaluatedValue = conditionValue == attributeValue;
@@ -410,7 +408,6 @@ class GBConditionEvaluator {
         conditionValue as String;
         attributeValue as String;
         switch (operator) {
-
           /// Evaluate EQ operator - whether condition equals to attribute
           case '\$eq':
             evaluatedValue = conditionValue == attributeValue;
@@ -423,6 +420,45 @@ class GBConditionEvaluator {
           // Evaluate LT operator - whether attribute less than to condition
           case '\$lt':
             evaluatedValue = attributeValue < conditionValue;
+            break;
+
+          // Evaluate VEQ operator - whether attribute version equals the condition version
+          case '\$veq':
+            evaluatedValue = GBUtils.paddedVersionString(attributeValue) ==
+                GBUtils.paddedVersionString(conditionValue);
+            break;
+          // Evaluate VNE operator - whether attribute version does not equal the condition version
+          case '\$vne':
+            evaluatedValue = GBUtils.paddedVersionString(attributeValue) !=
+                GBUtils.paddedVersionString(conditionValue);
+            break;
+          // Evaluate VGT operator - whether attribute version is greater than the condition version
+          case '\$vgt':
+            evaluatedValue = GBUtils.paddedVersionString(attributeValue) >
+                GBUtils.paddedVersionString(conditionValue);
+            break;
+          // Evaluate VGT operator - whether attribute version is greater than or equal to the condition version
+          case '\$vgte':
+            final attributeVersion =
+                GBUtils.paddedVersionString(attributeValue);
+            final conditionVersion =
+                GBUtils.paddedVersionString(conditionValue);
+            evaluatedValue = (attributeVersion == conditionVersion) ||
+                (attributeVersion > conditionVersion);
+            break;
+          // Evaluate VLT operator - whether attribute version is less than the condition version
+          case '\$vlt':
+            evaluatedValue = GBUtils.paddedVersionString(attributeValue) <
+                GBUtils.paddedVersionString(conditionValue);
+            break;
+          // Evaluate VLTE operator - whether attribute version is less than or equal to the condition version
+          case '\$vlte':
+            final attributeVersion =
+                GBUtils.paddedVersionString(attributeValue);
+            final conditionVersion =
+                GBUtils.paddedVersionString(conditionValue);
+            evaluatedValue = (attributeVersion == conditionVersion) ||
+                (attributeVersion < conditionVersion);
             break;
 
           /// Evaluate LTE operator - whether attribute less than or equal to condition

--- a/lib/src/Utils/gb_utils.dart
+++ b/lib/src/Utils/gb_utils.dart
@@ -117,4 +117,30 @@ class GBUtils {
 
     return null;
   }
+
+  static String paddedVersionString(String input) {
+    // Remove build info and leading `v` if any
+    // Split version into parts (both core version numbers and pre-release tags)
+    // "v1.2.3-rc.1+build123" -> ["1","2","3","rc","1"]
+    final parts = input
+        .replaceAll(
+          RegExp(r"(^v|\+.*$)"),
+          "",
+        )
+        .split(RegExp(r"[-.]"));
+
+    // If it's SemVer without a pre-release, add `~` to the end
+    // ["1","0","0"] -> ["1","0","0","~"]
+    // "~" is the largest ASCII character, so this will make "1.0.0" greater than "1.0.0-beta" for example
+    if (parts.length == 3) {
+      parts.add("~");
+    }
+
+    // Left pad each numeric part with spaces so string comparisons will work ("9">"10", but " 9"<"10")
+    // Then, join back together into a single string
+    final digits = RegExp(r"^[0-9]+$");
+    return parts
+        .map((v) => digits.hasMatch(v) ? v.padLeft(5, " ") : v)
+        .join("-");
+  }
 }

--- a/test/test_cases/test_case.dart
+++ b/test/test_cases/test_case.dart
@@ -1318,8 +1318,426 @@ const String gbTestCases = r'''
             "tags": "hello world"
           },
           false
+        ],
+        [
+          "$vgt/$vlt - pass - major",
+          {
+            "version": {
+              "$vgt": "9.99.8",
+              "$vlt": "11.0.1"
+            }
+          },
+          {
+            "version": "10.12.13"
+          },
+          true
+        ],
+        [
+          "$vgt/$vlt - pass - minor",
+          {
+            "version": {
+              "$vgt": "10.2.11",
+              "$vlt": "10.20.11"
+            }
+          },
+          {
+            "version": "10.12.11"
+          },
+          true
+        ],
+        [
+          "$vgt/$vlt - pass - patch",
+          {
+            "version": {
+              "$vgt": "10.0.2",
+              "$vlt": "10.0.20"
+            }
+          },
+          {
+            "version": "10.0.12"
+          },
+          true
+        ],
+        [
+          "$vgt/$vlt - fail $vlt - major",
+          {
+            "version": {
+              "$vgt": "30.0.0",
+              "$vlt": "50.0.0"
+            }
+          },
+          {
+            "version": "60.0.0"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt - fail $vlt - minor",
+          {
+            "version": {
+              "$vgt": "10.30.0",
+              "$vlt": "10.50.0"
+            }
+          },
+          {
+            "version": "10.60.0"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt - fail $vlt - patch",
+          {
+            "version": {
+              "$vgt": "10.2.30",
+              "$vlt": "10.2.50"
+            }
+          },
+          {
+            "version": "10.2.60"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt - fail $vgt - major",
+          {
+            "version": {
+              "$vgt": "30.0.16",
+              "$vlt": "50.0.16"
+            }
+          },
+          {
+            "version": "20.0.16"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt - fail $vgt - minor",
+          {
+            "version": {
+              "$vgt": "10.30.0",
+              "$vlt": "10.50.0"
+            }
+          },
+          {
+            "version": "10.20.0"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt - fail $vgt - patch",
+          {
+            "version": {
+              "$vgt": "10.30.10",
+              "$vlt": "10.30.20"
+            }
+          },
+          {
+            "version": "10.30.2"
+          },
+          false
+        ],
+        [
+          "$vgte/$vlte - pass $vgte - major",
+          {
+            "version": {
+              "$vgte": "30.1.2",
+              "$vlte": "60.1.2"
+            }
+          },
+          {
+            "version": "30.1.2"
+          },
+          true
+        ],
+        [
+          "$vgte/$vlte - pass $vgte - minor",
+          {
+            "version": {
+              "$vgte": "5.30.2",
+              "$vlte": "5.60.2"
+            }
+          },
+          {
+            "version": "5.30.2"
+          },
+          true
+        ],
+        [
+          "$vgte/$vlte - pass $vgte - patch",
+          {
+            "version": {
+              "$vgte": "5.10.30",
+              "$vlte": "5.10.60"
+            }
+          },
+          {
+            "version": "5.10.30"
+          },
+          true
+        ],
+        [
+          "$vgte/$vlte - pass $vlte - major",
+          {
+            "version": {
+              "$vgte": "30.1.2",
+              "$vlte": "60.1.2"
+            }
+          },
+          {
+            "version": "60.1.2"
+          },
+          true
+        ],
+        [
+          "$vgte/$vlte - pass $vlte - minor",
+          {
+            "version": {
+              "$vgte": "1.30.2",
+              "$vlte": "1.60.2"
+            }
+          },
+          {
+            "version": "1.60.2"
+          },
+          true
+        ],
+        [
+          "$vgte/$vlte - pass $vlte - patch",
+          {
+            "version": {
+              "$vgte": "1.2.30",
+              "$vlte": "1.2.60"
+            }
+          },
+          {
+            "version": "1.2.60"
+          },
+          true
+        ],
+        [
+          "$vgte/$vlte - fail $vlte - major",
+          {
+            "version": {
+              "$vgte": "30.1.2",
+              "$vlte": "60.1.2"
+            }
+          },
+          {
+            "version": "61.1.2"
+          },
+          false
+        ],
+        [
+          "$vgte/$vlte - fail $vgt - minor",
+          {
+            "version": {
+              "$vgte": "30.1.2",
+              "$vlte": "60.1.2"
+            }
+          },
+          {
+            "version": "29.1.2"
+          },
+          false
+        ],
+        [
+          "$vgte/$vlte - fail $vgt - patch",
+          {
+            "version": {
+              "$vgte": "1.2.30",
+              "$vlte": "1.2.60"
+            }
+          },
+          {
+            "version": "1.2.29"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt prerelease - fail $vgt",
+          {
+            "v": {
+              "$vgt": "1.0.0-alpha",
+              "$vlt": "1.0.0-beta"
+            }
+          },
+          {
+            "v": "1.0.0-alpha"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt prerelease  w/ multiple fields - fail $vgt",
+          {
+            "v": {
+              "$vgt": "1.0.0-alpha.2",
+              "$vlt": "1.0.0-beta.1"
+            }
+          },
+          {
+            "v": "1.0.0-alpha.1"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt prerelease - fail $vlt",
+          {
+            "v": {
+              "$vgt": "1.0.0-alpha",
+              "$vlt": "1.0.0-beta"
+            }
+          },
+          {
+            "v": "1.0.0-beta"
+          },
+          false
+        ],
+        [
+          "$vgt/$vlt prerelease - pass",
+          {
+            "v": {
+              "$vgt": "1.0.0-alpha",
+              "$vlt": "1.0.0-beta"
+            }
+          },
+          {
+            "v": "1.0.0-alpha.10"
+          },
+          true
+        ],
+        [
+          "$vgt/$vlt prerelease - fail uppercase",
+          {
+            "v": {
+              "$vgt": "1.0.0-alpha",
+              "$vlt": "1.0.0-beta"
+            }
+          },
+          {
+            "v": "1.0.0-ALPHA"
+          },
+          false
+        ],
+        [
+          "$veq - pass",
+          {
+            "v": {
+              "$veq": "1.2.3"
+            }
+          },
+          {
+            "v": "1.2.3"
+          },
+          true
+        ],
+        [
+          "$veq - pass (with build)",
+          {
+            "v": {
+              "$veq": "1.2.3"
+            }
+          },
+          {
+            "v": "1.2.3+build.abc.123"
+          },
+          true
+        ],
+        [
+          "$vne - pass",
+          {
+            "v": {
+              "$vne": "1.2.3"
+            }
+          },
+          {
+            "v": "2.2.3"
+          },
+          true
+        ],
+        [
+          "$vne - pass (prerelease)",
+          {
+            "v": {
+              "$vne": "1.2.3"
+            }
+          },
+          {
+            "v": "1.2.3-alpha"
+          },
+          true
         ]
       ],
+      "versionCompare": {
+        "lt": [
+          ["0.9.99", "1.0.0", true],
+          ["0.9.0", "0.10.0", true],
+          ["1.0.0-0.0", "1.0.0-0.0.0", true],
+          ["1.0.0-9999", "1.0.0--", true],
+          ["1.0.0-99", "1.0.0-100", true],
+          ["1.0.0-alpha", "1.0.0-alpha.1", true],
+          ["1.0.0-alpha.1", "1.0.0-alpha.beta", true],
+          ["1.0.0-alpha.beta", "1.0.0-beta", true],
+          ["1.0.0-beta", "1.0.0-beta.2", true],
+          ["1.0.0-beta.2", "1.0.0-beta.11", true],
+          ["1.0.0-beta.11", "1.0.0-rc.1", true],
+          ["1.0.0-rc.1", "1.0.0", true],
+          ["1.0.0-0", "1.0.0--1", true],
+          ["1.0.0-0", "1.0.0-1", true],
+          ["1.0.0-1.0", "1.0.0-1.-1", true]
+        ],
+        "gt": [
+          ["0.0.0", "0.0.0-foo", true],
+          ["0.0.1", "0.0.0", true],
+          ["1.0.0", "0.9.9", true],
+          ["0.10.0", "0.9.0", true],
+          ["0.99.0", "0.10.0", true],
+          ["2.0.0", "1.2.3", true],
+          ["v0.0.0", "0.0.0-foo", true],
+          ["v0.0.1", "0.0.0", true],
+          ["v1.0.0", "0.9.9", true],
+          ["v0.10.0", "0.9.0", true],
+          ["v0.99.0", "0.10.0", true],
+          ["v2.0.0", "1.2.3", true],
+          ["0.0.0", "v0.0.0-foo", true],
+          ["0.0.1", "v0.0.0", true],
+          ["1.0.0", "v0.9.9", true],
+          ["0.10.0", "v0.9.0", true],
+          ["0.99.0", "v0.10.0", true],
+          ["2.0.0", "v1.2.3", true],
+          ["1.2.3", "1.2.3-asdf", true],
+          ["1.2.3", "1.2.3-4", true],
+          ["1.2.3", "1.2.3-4-foo", true],
+          ["1.2.3-5-foo", "1.2.3-5", true],
+          ["1.2.3-5", "1.2.3-4", true],
+          ["1.2.3-5-foo", "1.2.3-5-Foo", true],
+          ["3.0.0", "2.7.2+asdf", true],
+          ["1.2.3-a.10", "1.2.3-a.5", true],
+          ["1.2.3-a.b", "1.2.3-a.5", true],
+          ["1.2.3-a.b", "1.2.3-a", true],
+          ["1.2.3-a.b.c", "1.2.3-a.b.c.d", false],
+          ["1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100", true],
+          ["1.2.3-r2", "1.2.3-r100", true],
+          ["1.2.3-r100", "1.2.3-R2", true],
+          ["a.b.c.d.e.f", "1.2.3", true],
+          ["10.0.0", "9.0.0", true],
+          ["10000.0.0", "9999.0.0", true]
+        ],
+        "eq": [
+          ["1.2.3", "1.2.3", true],
+          ["1.2.3", "v1.2.3", true],
+          ["1.2.3-0", "v1.2.3-0", true],
+          ["1.2.3-1", "1.2.3-1", true],
+          ["1.2.3-1", "v1.2.3-1", true],
+          ["1.2.3-beta", "1.2.3-beta", true],
+          ["1.2.3-beta", "v1.2.3-beta", true],
+          ["1.2.3-beta+build", "1.2.3-beta+otherbuild", true],
+          ["1.2.3-beta+build", "v1.2.3-beta+otherbuild", true],
+          ["1-2-3", "1.2.3", true],
+          ["1-2-3", "1-2.3+build99", true],
+          ["1-2-3", "v1.2.3", true],
+          ["1.2.3.4", "1.2.3-4", true]
+        ]
+      },
       "hash": [
         [
           "a",


### PR DESCRIPTION
Adds support for version string comparison operators.

This is a port of the original feature implementation in Growthbook 2.2.

Addresses https://github.com/alippo-com/GrowthBook-SDK-Flutter/issues/53